### PR TITLE
Fix bug html path

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v1.0.0, 2018-11-13 -- Initial release, envolved from django-template-finder-view
 v1.1.0, 2018-11-13 -- Base template finding and parsing off existing Django templates; remove TEMPLATE_FINDER_PATH
 v1.1.1, 2018-11-13 -- Avoid .endswith error for 404 URLs
 v1.2.0, 2018-11-20 -- Support table in lists
+v1.3.0, 2018-11-27 -- Support path with direct html files

--- a/canonicalwebteam/django_views/__init__.py
+++ b/canonicalwebteam/django_views/__init__.py
@@ -51,7 +51,9 @@ def _find_matching_template(path):
     """
 
     # Try to match HTML or Markdown files
-    if _template_exists(path + ".html"):
+    if _template_exists(path):
+        return path
+    elif _template_exists(path + ".html"):
         return path + ".html"
     elif _template_exists(os.path.join(path, "index.html")):
         return os.path.join(path, "index.html")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='canonicalwebteam.django_views',
-    version='1.2.0',
+    version='1.3.0',
     author='Canonical webteam',
     author_email='webteam@canonical.com',
     url='https://github.com/canonicalwebteam/django_views',


### PR DESCRIPTION
when accessing a page like /index.html that path generated was: templates/index.html/index.html even when index.html exists because the code adds a `.html` to every path given to the function
By checking if the template exists we remove this problem.

You can try to access maas.io/index.html we get a 500