### PR TITLE
v1.3.4: Python2 support for _template_exists function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,3 +5,4 @@ v1.2.0, 2018-11-20 -- Support table in lists
 v1.2.1, 2018-11-29 -- Complete test coverage
 v1.3.2, 2018-12-05 -- Case-insensitive matching
 v1.3.3, 2018-12-19 -- Fix 500 error with full filenames in URLs
+v1.3.4, 2019-02-07 -- Make _template_exists Python2 compatible

--- a/canonicalwebteam/django_views/__init__.py
+++ b/canonicalwebteam/django_views/__init__.py
@@ -35,7 +35,7 @@ def _template_exists(path):
     try:
         loader.get_template(path)
         return True
-    except (TemplateDoesNotExist, NotADirectoryError):
+    except (TemplateDoesNotExist, OSError):
         return False
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='canonicalwebteam.django_views',
-    version='1.3.3',
+    version='1.3.4',
     author='Canonical webteam',
     author_email='webteam@canonical.com',
     url='https://github.com/canonicalwebteam/django_views',


### PR DESCRIPTION
## QA

First, have www.ubuntu.com master branch and this branch in folders next to each other. Let's assume the two directories are called `www.ubuntu.com` and `django-views`:

``` bash
cd www.ubuntu.com
./run build
virtualenv env2
source env2/bin/activate
pip install -r requirements.txt
python manage.py runserver
```

Now go to http://localhost:8000, you should see an error page. Now kill the server and:

``` bash
pip install ../django-views
python manage.py runserver
```

Now go to http://localhost:8000 again - it should work now.
